### PR TITLE
Fix crash NSPredicate Crash

### DIFF
--- a/Music Player/DownloadManager.swift
+++ b/Music Player/DownloadManager.swift
@@ -84,11 +84,15 @@ class DownloadManager {
     
     fileprivate func updateStoredSongs(){
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Song")
-        request.predicate = NSPredicate(format: "isDownloaded = %@", true as CVarArg)
-        
+
         let songs = try? context.fetch(request)
         downloadedIDs = []
         for song in songs!{
+            let isDownloaded = (song as AnyObject).value(forKey: "isDownloaded") as! Bool
+            if !isDownloaded {
+                continue
+            }
+
             let identifier = (song as AnyObject).value(forKey: "identifier") as! String
             downloadedIDs += [identifier]
         }


### PR DESCRIPTION
Unfortunately, the app crashes whenever I click on the "add" button for navigating on Youtube. I do not know why it crashes, but the removal of the NSPredicate actually fixed the crash. This is a workaround and works for iOS 12. You do not need to accept the PR since this a workaround.